### PR TITLE
Dedis library fix

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -12,10 +12,10 @@ import (
 	"sync"
 	"time"
 
-	. "github.com/kwonalbert/riffle/lib" //types and utils
+	. "github.com/optimisticninja/riffle/lib" //types and utils
 
-	"github.com/dedis/crypto/abstract"
-	"github.com/dedis/crypto/edwards"
+	"gopkg.in/dedis/crypto.v0/abstract"
+	"gopkg.in/dedis/crypto.v0/edwards"
 
 	"golang.org/x/crypto/nacl/secretbox"
 	"golang.org/x/crypto/sha3"

--- a/lib/utils.go
+++ b/lib/utils.go
@@ -13,8 +13,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dedis/crypto/abstract"
-	"github.com/dedis/crypto/random"
+	"gopkg.in/dedis/crypto.v0/abstract"
+	"gopkg.in/dedis/crypto.v0/random"
 )
 
 func SetBit(n_int int, b bool, bs []byte) {

--- a/server/server.go
+++ b/server/server.go
@@ -17,12 +17,12 @@ import (
 
 	"time"
 
-	. "github.com/kwonalbert/riffle/lib" //types and utils
+	. "github.com/optimisticninja/riffle/lib" //types and utils
 
-	"github.com/dedis/crypto/abstract"
-	"github.com/dedis/crypto/edwards"
-	"github.com/dedis/crypto/proof"
-	"github.com/dedis/crypto/shuffle"
+	"gopkg.in/dedis/crypto.v0/abstract"
+	"gopkg.in/dedis/crypto.v0/edwards"
+	"gopkg.in/dedis/crypto.v0/proof"
+	"gopkg.in/dedis/crypto.v0/shuffle"
 
 	"golang.org/x/crypto/nacl/secretbox"
 	"golang.org/x/crypto/sha3"


### PR DESCRIPTION
For the short term I modified the imports to use a gopkg.in for the old crypto version since the library has been heavily changed and is now named kyber. I will update again with the new library. Please remember to modify github back to kwonalbert in the import for client and server.

Thank you for your hard work! Not letting such a beautiful project go to waste.